### PR TITLE
added checked:after = none

### DIFF
--- a/SCSS/_blocks/_listings/_task-list.scss
+++ b/SCSS/_blocks/_listings/_task-list.scss
@@ -48,6 +48,10 @@
 
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath d='M7.74,15.63a1.45,1.45,0,0,1-1.06-.44L2.94,11.46A1.5,1.5,0,0,1,5.06,9.34L7.74,12l7.2-7.2a1.5,1.5,0,1,1,2.12,2.12L8.8,15.19A1.48,1.48,0,0,1,7.74,15.63Z' style='fill:%230c0c0c'/%3E%3C/svg%3E");
   }
+  .task-list-item-checkbox:checked::after {
+    display: none;
+  }
+
 }
 
 .markdown-source-view.mod-cm6


### PR DESCRIPTION
#52 fix proposal - added `display:none` for `checked:after` - based on suggestion by @wobbba.

Initially tested using dev tools in Obsidian and applying fix into my Vault - additional check ticks disappeared.