### PR TITLE
Fix blockquotes styling

### DIFF
--- a/SCSS/_blocks/_blockquotes.scss
+++ b/SCSS/_blocks/_blockquotes.scss
@@ -15,7 +15,6 @@
   border-left-width: var(--size-1);
   border-radius: var(--size-1);
   background-color: var(--background-primary);
-  padding: 1em;
 
   span.cm-quote {
     color: var(--main-text);


### PR DESCRIPTION
Hi, I recently started using this theme and I'm loving it, so I wanted to help fix some issues.
This fixes #47 by removing the excessive padding from blockquotes.

## Before
![image](https://github.com/user-attachments/assets/2ca56ac8-6b58-4501-ab5b-66a3f57b17e5)

## After
![image](https://github.com/user-attachments/assets/726baec1-6ec9-47dd-89f0-418eeb2ccec6)
